### PR TITLE
Improved output handling an new info to doc added to Gray code deco peripheral

### DIFF
--- a/docs/user_peripherals/16_gray.md
+++ b/docs/user_peripherals/16_gray.md
@@ -47,6 +47,8 @@ You can feed any binary number to the data_in input with the data_write set and 
 
 For Gray decoder, You can feed any Gray number to the data_in input with the data_write set and adrress == "2". It will output Binary decoded to data_out and uo_out
 
+Output is driven by 'data_write' and 'rst_n'. Each time you set 'data_write' means a new convertion and output, you can clear out by 'rst_n' or writing any data to 'clear_output' address.
+
 ## External hardware
 
 You can connect output from this peripheral to any input wich can encod/decod gray or need any gray interface for communication.

--- a/src/user_peripherals/tqvp_gera_gray.v
+++ b/src/user_peripherals/tqvp_gera_gray.v
@@ -34,7 +34,7 @@ module tqvp_gera_gray_coder (
     //Internal reg
     reg [7:0] bin_reg;
     reg [7:0] gray_reg;
-    reg [3:0] out_flag = 4'b0000;
+    reg [3:0] out_flag;
     
     integer i;
     
@@ -46,13 +46,14 @@ module tqvp_gera_gray_coder (
         if (!rst_n) begin
             bin_reg <= 0;
             gray_reg <= 0;
-            out_flag <= 4'b0000;
+            out_flag <= 0;
         end else begin
             if (data_write) begin
                 case (address)
                     clear_output: begin
                         gray_reg <= 0;
                         bin_reg <= 0;
+                        out_flag <= 0;
                     end
                     Bin_2_Gray: begin
                         gray_reg <= data_in;

--- a/src/user_peripherals/tqvp_gera_gray.v
+++ b/src/user_peripherals/tqvp_gera_gray.v
@@ -34,7 +34,10 @@ module tqvp_gera_gray_coder (
     //Internal reg
     reg [7:0] bin_reg;
     reg [7:0] gray_reg;
+    reg [3:0] out_flag = 4'b0000;
+    
     integer i;
+    
     //Output wires
     wire [7:0] bin_out;
     wire [7:0] gray_out;
@@ -43,6 +46,7 @@ module tqvp_gera_gray_coder (
         if (!rst_n) begin
             bin_reg <= 0;
             gray_reg <= 0;
+            out_flag <= 4'b0000;
         end else begin
             if (data_write) begin
                 case (address)
@@ -52,9 +56,11 @@ module tqvp_gera_gray_coder (
                     end
                     Bin_2_Gray: begin
                         gray_reg <= data_in;
+                        out_flag <= Bin_2_Gray;
                     end
                     Gray_2_Bin: begin
                         bin_reg <= data_in;
+                        out_flag <= Gray_2_Bin;
                     end
 
                     default: begin 
@@ -88,12 +94,12 @@ module tqvp_gera_gray_coder (
     //Both output are written pmod and data out
 
     // All output pins must be assigned. If not used, assign to 0.
-    assign uo_out  =  (address == Bin_2_Gray) ? gray_out :
-                      (address == Gray_2_Bin) ? bin_out :
+    assign uo_out  =  (out_flag == Bin_2_Gray) ? gray_out :
+                      (out_flag == Gray_2_Bin) ? bin_out :
                       8'h0;
 
-    assign data_out = (address == Bin_2_Gray) ? gray_out :
-                      (address == Gray_2_Bin) ? bin_out :
+    assign data_out = (out_flag == Bin_2_Gray) ? gray_out :
+                      (out_flag == Gray_2_Bin) ? bin_out :
                       8'h0;    
     // List all unused inputs to prevent warnings
     wire _unused = &{ui_in, 1'b0};


### PR DESCRIPTION
Thank you for entering the TinyQV Risc-V Peripheral Challenge!

I have added a new reg which will drive outputs according to a new 'address' change only if  "data_write" is set. This way no matter 'address' is, it will not change unless a new "clear_output" command or "reset" is writing. 

Also, I have added this info to doc file.

My peripheral repo was already updated with these changes.

Link to your peripheral repo: https://github.com/Gerard-170/tinyqv-byte-peripheral-gray