### PR TITLE
Fixes & improvements: 64MHz, data_ready low on read, default resolution 20x16.

### DIFF
--- a/docs/user_peripherals/12_vga.md
+++ b/docs/user_peripherals/12_vga.md
@@ -23,33 +23,25 @@ TODO: Explain what your peripheral does and how it works
 
 ## Register map
 
-| Address | Name    | Access | Description                                                      |
-|---------|---------|--------|------------------------------------------------------------------|
-| 0x00    | PIXDAT0 | W      | Pixel data (1-bit per pixel)   0..31                             |
-| 0x04    | PIXDAT1 | W      | Pixel data (1-bit per pixel)  32..63                             |
-| 0x08    | PIXDAT2 | W      | Pixel data (1-bit per pixel)  64..xx                             |
-| 0x0C    | PIXDAT3 | W      | Pixel data (1-bit per pixel)  xx..xx                             |
-| 0x10    | PIXDAT4 | W      | Pixel data (1-bit per pixel)  xx..xx                             |
-| 0x14    | PIXDAT5 | W      | Pixel data (1-bit per pixel)  xx..xx                             |
-| 0x18    | PIXDAT6 | W      | Pixel data (1-bit per pixel)  xx..xx                       		|
-| 0x1C    | PIXDAT7 | W      | Pixel data (1-bit per pixel) 224..255                            |
-| 0x20    | PIXDAT8 | W      | Pixel data (1-bit per pixel)  xx..xx                             |
-| 0x24    | PIXDAT9 | W      | Pixel data (1-bit per pixel) 288..x319                           |
-| 0x30	  | BGCOLOR | W	     | Background color: xxBBGGRR, default 010000 = dark blue			|
-| 0x31	  | FGCOLOR	| W		 | Foreground color: xxBBGGRR, default 001011 = golden yellow		|
-| 0x32	  | P2COLOR	| W		 | 3rd color, if 4 color palette enabled: xxBBGGRR |
-| 0x33	  | P3COLOR	| W		 | 3th color, if 4 color palette enabled: xxBBGGRR |
-| 0x34	  | STRIDE	| W		 | VRAM bit stride per pixel row (bits 8..0), default 20. Setting -1 will reset VRAM index to 0 on the next pixel row |
-| 0x38	  | PIXSIZE	| W		 | Pixel size: width in clocks (bits 6..0), height in scanlines (bits 22..16) |
-| 0x3C	  | MODE	| W		 | Interrupt: 0=frame, 1=scanline, 2=pixel row, 3=disabled (bits 1..0) |
-|    	  |     	|  		 | Screen width: 0=1024, 1=960 clocks (bit 2) |
-|		  |         |        | Color mode: 0=2 colors, 1=4 color palette |
+| Address    | Name       | Access      | Description                                                      |
+|------------|------------|-------------|------------------------------------------------------------------|
+| 0x00..0x27 | PIXELS     | W 32bit     | Pixel data VRAM contains either 320 1-bit or 160 2-bit pixels    |
+| 0x30       | COLOR_0    | W 32/16/8bit| Background color: xxBBGGRR, default 010000 = dark blue           |
+| 0x31       | COLOR_1    | W 8bit      | Foreground color: xxBBGGRR, default 001011 = golden yellow       |
+| 0x32       | COLOR_2    | W 16/8bit   | 3rd color, when 4 color mode is enabled: xxBBGGRR                |
+| 0x33       | COLOR_3    | W 8bit      | 4th color, when 4 color mode is enabled: xxBBGGRR                |
+| 0x34       | PIXEL_SIZE | W 8bit      | Pixel size: width in clocks (bits 6..0), height in scanlines (bits 22..16) |
+| 0x38       | VRAM_STRIDE| W 32/16bit	| VRAM bit stride per pixel row (bits 8..0), default 20. Setting -1 will reset VRAM index to 0 on the next pixel row |
+| 0x3C	     | MODE	      | W	32/16/8bit| Interrupt: 0=frame, 1=scanline, 2=pixel row, 3=disabled (bits 1..0) |
+|            |            |          | Pixel clock: 0=64 MHz 804 scanlines, 1=63.5 MHz 798 scanlines (bit 4) |
+|            |            |          | Screen width: 0=1024, 1=960 clocks (bit 5) |
+|            |            |          | Color mode: 0=2 colors, 1=4 color palette (bit 6) |
 
 | Address | Name        | Access | Description                                                  |
 |---------|-------------|--------|--------------------------------------------------------------|
 | 0x00    | WAIT_HBLANK | R      | Block CPU waiting for Horizontal BLANK                       |
 | 0x04    | WAIT_PIXEL0 | R      | Block CPU waiting for display to reach the 1st pixel of the buffer |
-| 0x08    | SCANLINE    | R      | Returns current scanlineL: 0..767 visible portion of the screen, >=768 offscreen |
+| 0x08    | SCANLINE    | R      | Returns current scanline: 0..767 visible portion of the screen, >=768 offscreen |
 
 ## How to test
 

--- a/src/user_peripherals/vga/peripheral.v
+++ b/src/user_peripherals/vga/peripheral.v
@@ -215,7 +215,7 @@ module tqvp_rejunity_vga (
         .enable_interrupt_on_hblank(vga_ei_hblank),
         .enable_interrupt_on_vblank(vga_ei_vblank),
         .narrow_960(vga_960_vs_1024),
-        .extra_vblank_lines_for_64mhz(vga_63_5mhz),
+        .extra_vblank_lines_for_64mhz(~vga_63_5mhz),
         .x(vga_x),
         .y(vga_y),
         .hsync(vga_hsync),

--- a/src/user_peripherals/vga/vga_timing.v
+++ b/src/user_peripherals/vga/vga_timing.v
@@ -1,16 +1,51 @@
 `default_nettype none
 
+// VGA timing for 64 MHz base clock.
+//
+// This code is based on the previous implementations by RebelMike, hftab and ccattuto,
+// as well as informative discussions on TinyTapeout discord channels.
 
-// https://tomverbeure.github.io/2019/08/03/Video-Timings-Calculator.html
-// https://tomverbeure.github.io/video_timings_calculator?horiz_pixels=1024&vert_pixels=768&refresh_rate=60&margins=false&interlaced=false&bpc=8&color_fmt=rgb444&video_opt=false&custom_hblank=80&custom_vblank=6
+// Graphics mode: 1024x768 60Hz CVT
+// 63.5 MHz pixel clock, rounded to 64 MHz
+// (courtesy of RebelMike)
 
-module vga_timing_rejunity (
+// Timing calculations were made with:
+//      https://tomverbeure.github.io/2019/08/03/Video-Timings-Calculator.html
+// Parameters:
+//      horiz_pixels=1024
+//      vert_pixels=768
+//      refresh_rate=60
+//      margins=false
+//      interlaced=false
+//      bpc=8
+//      color_fmt=rgb444
+//      video_opt=false
+//      custom_hblank=80
+//      custom_vblank=6
+
+
+// NOTES:
+// 1) SCREEN WIDTH. Although ~64 MHz clock provides standard 1024 clock / pixel wide screen,
+// 1024 wide does not suit lower 320 / 640 pixel resolutions - no simple divisor.
+// The closest divisable 960 can be achieved by adding 32 clock borders:
+//      (1024 - 960) / 2 = 32 additional border clocks
+// thus the optional 'narrow_960' mode.
+//
+// 2) SCANLINE COUNT. 64 MHz clock is slightly higher than 
+// the nominal 63.5 MHz pixel clock mandated by 1024x768 60Hz CVT.
+// As a stopgap solution extra scanlines can be added during the vertical blanking period:
+//      798 total vertical lines / 63.5 * 64 = 804 total vertical lines
+// thus the optional `extra_scanlines_for_64mhz` mode.
+
+
+module vga_timing (
     input wire clk,
     input wire rst_n,
     input wire cli,
     input wire enable_interrupt_on_hblank,
     input wire enable_interrupt_on_vblank,
     input wire narrow_960,
+    input wire extra_vblank_lines_for_64mhz,
     output reg [10:0] x,
     output reg [ 9:0] y,
     output reg hsync,
@@ -20,33 +55,17 @@ module vga_timing_rejunity (
     output reg interrupt
 );
 
-// 1024x768 60Hz CVT (63.5 MHz pixel clock, rounded to 64 MHz) - courtesy of RebelMike
-
-// `define H_ROLL   31
-// `define H_FPORCH (32 * 32)
-// `define H_SYNC   (33 * 32 + 16)
-// `define H_BPORCH (36 * 32 + 24)
-// `define H_NEXT   (41 * 32 + 15)
-
-// `define V_ROLL   47
-// `define V_FPORCH (16 * 64)
-// `define V_SYNC   (16 * 64 + 3)
-// `define V_BPORCH (16 * 64 + 7)
-// `define V_NEXT   (16 * 64 + 29)
 
 // 1024
 //  |          visible           |  blank |-=HSYNC=-|  blank  |
 //  |<---------- 1024 ---------->|<--48-->|<--104-->|<--151-->|
 //  0                            1024     1072      1176      1327
 
-// 960, additional blanks left&right 32 = (1024-960)/2
+// 960, additional blanks left & right 32 = (1024-960)/2
 //  |     visible    |     blank    |-=HSYNC=-|      blank    |
 //  |<----- 960 ---->|<-32-><--48-->|<--104-->|<--151--><-32->|
 //  0                960            1040      1144            1327
 
-//`define H_FPORCH 1024
-// `define H_SYNC   1072
-// `define H_BPORCH 1176
 `define H_FPORCH (narrow_960 ?  960 : 1024)
 `define H_SYNC   (narrow_960 ? 1040 : 1072)
 `define H_BPORCH (narrow_960 ? 1144 : 1176)
@@ -55,8 +74,7 @@ module vga_timing_rejunity (
 `define V_FPORCH 768
 `define V_SYNC   771
 `define V_BPORCH 775
-`define V_NEXT   797 // 803 
-
+`define V_NEXT   (extra_vblank_lines_for_64mhz ? 803 : 797)
 
 always @(posedge clk) begin
     if (!rst_n) begin
@@ -94,46 +112,5 @@ always @(posedge clk) begin
 end
 
 assign blank = (x >= `H_FPORCH || y >= `V_FPORCH);
-
-// always @(posedge clk) begin
-//     if (!rst_n) begin
-//         x_hi <= 0;
-//         x_lo <= 0;
-//         y_hi <= 0;
-//         y_lo <= 0;
-//         hsync <= 0;
-//         vsync <= 0;
-//         interrupt <= 0;
-//     end else begin
-//         if ({x_hi, x_lo} == `H_NEXT) begin
-//             x_hi <= 0;
-//             x_lo <= 0;
-//         end else if (x_lo == `H_ROLL) begin
-//             x_hi <= x_hi + 1;
-//             x_lo <= 0;
-//         end else begin
-//             x_lo <= x_lo + 1;
-//         end
-//         if ({x_hi, x_lo} == `H_SYNC) begin
-//             if({y_hi, y_lo} == `V_NEXT) begin
-//                 y_hi <= 0;
-//                 y_lo <= 0;
-//                 interrupt <= 1;
-//             end else if (y_lo == `V_ROLL) begin
-//                 y_hi <= y_hi + 1;
-//                 y_lo <= 0;
-//             end else begin
-//                 y_lo <= y_lo + 1;
-//             end
-//         end
-//         hsync <= !({x_hi, x_lo} >= `H_SYNC && {x_hi, x_lo} < `H_BPORCH);
-//         vsync <= ({y_hi, y_lo} >= `V_SYNC && {y_hi, y_lo} < `V_BPORCH);
-//         if (cli || {y_hi, y_lo} == 0) begin
-//             interrupt <= 0;
-//         end
-//     end
-// end
-
-// assign blank = ({x_hi, x_lo} >= `H_FPORCH || {y_hi, y_lo} >= `V_FPORCH);
 
 endmodule


### PR DESCRIPTION
1) Fixed 1 cycle delayed data_ready.
2) 64 MHz scanlines
3) default 20x16 resolution
3) Moved register locations around.

Link to your peripheral repo: https://github.com/rejunity/tinyqv-full-peripheral-vga/actions/runs/17508642155